### PR TITLE
Update links for for HACS

### DIFF
--- a/components/hacs.json
+++ b/components/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "hacs",
   "owner": ["ludeeus"],
-  "manifest": "https://raw.githubusercontent.com/custom-components/hacs/master/custom_components/hacs/manifest.json",
-  "url": "https://github.com/custom-components/hacs"
+  "manifest": "https://raw.githubusercontent.com/hacs/integration/master/custom_components/hacs/manifest.json",
+  "url": "https://github.com/hacs/integration"
 }


### PR DESCRIPTION
The repository for HACS has moved, this PR updates the links.